### PR TITLE
Config shim initial support

### DIFF
--- a/nbclassic/notebookapp.py
+++ b/nbclassic/notebookapp.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import, print_function
 import os
 import gettext
 import random
+import sys
 import warnings
 
 from jinja2 import Environment, FileSystemLoader
@@ -43,6 +44,7 @@ from jupyter_server.serverapp import (
     random_ports,
     load_handlers
 )
+from .shimconfig import merge_notebook_configs
 
 #-----------------------------------------------------------------------------
 # Module globals
@@ -320,6 +322,14 @@ class NotebookApp(ExtensionApp):
             nbextensions_path=self.nbextensions_path,
         )
         self.settings.update(**settings)
+
+        merged_config = merge_notebook_configs(
+            notebook_config_name = 'jupyter_notebook',
+            server_config_name = 'jupyter_server',
+            other_config_name = 'jupyter_nbclassic', 
+            argv = sys.argv
+            )
+        self.settings['ServerApp'] = merged_config['ServerApp']
 
     def initialize_handlers(self):
         """Load the (URL pattern, handler) tuples for each component."""

--- a/nbclassic/shimconfig.py
+++ b/nbclassic/shimconfig.py
@@ -1,0 +1,43 @@
+import warnings
+from .shimwarning import shim_message
+from jupyter_core.application import JupyterApp
+from traitlets.config.loader import Config
+
+class ConfLoader(JupyterApp):
+    def __init__(self, name, argv):
+        self.name = name
+        self.load_config_file()
+        self.parse_command_line(argv)
+
+def load_config(conf_name, argv):
+    conf = ConfLoader(conf_name, argv)
+    return conf.config
+
+def shim_configs(notebook_config_name: None, server_config_name: None, extension_config_name: None, argv=None):
+
+    notebook_config = load_config(notebook_config_name, argv)
+    server_config = load_config(server_config_name, argv)
+    extension_config = load_config(extension_config_name, argv)
+
+    _print_warnings(notebook_config, server_config)
+
+    merged_config = Config()
+    merged_config.ServerApp = notebook_config.NotebookApp
+    merged_config.merge(notebook_config)
+    merged_config.merge(server_config)
+    merged_config.merge(extension_config)
+    return merged_config
+
+def _print_warnings(notebook_config, server_config):
+    deprecated = list(notebook_config.NotebookApp.keys())
+    if deprecated:
+        print("=========================================================================================")
+        print("You are using NotebookApp settings that will be deprecated at the next major notebook release.")
+        print("Please migrate following settings from NotebookApp to ServerApp:")
+        print("  {}".format(deprecated))
+        print("Read more on https://...")
+        print("=========================================================================================")
+        warnings.warn(
+            "NotebookApp configuration is deprecated. Migrate them to ServerApp",
+            DeprecationWarning, stacklevel=2,
+        )

--- a/nbclassic/shimconfig.py
+++ b/nbclassic/shimconfig.py
@@ -4,16 +4,32 @@ from jupyter_core.application import JupyterApp
 from traitlets.config.loader import Config
 
 class ConfLoader(JupyterApp):
+    """Rely on the JupyterApp class hierarchy to generated a 
+    well constructed configuration object based on the given name.
+    """
     def __init__(self, name, argv):
         self.name = name
         self.load_config_file()
         self.parse_command_line(argv)
 
 def load_config(conf_name, argv):
+    """Returns a Config object based on the given name
+    """
     conf = ConfLoader(conf_name, argv)
     return conf.config
 
 def shim_configs(notebook_config_name: None, server_config_name: None, extension_config_name: None, argv=None):
+    """Merge the notebook, server and your extension configurations and prints warnings in case
+    the notebook configuration still contains NotebookApp traits.
+  
+        Parameters: 
+            notebook_config_name (string): the name of the notebook configuration (e.g. jupyter_notebook)
+            server_config_name (string): the name of the notebook configuration (e.g. servrer_notebook)
+            ext_config_name (string): the name of the notebook configuration (e.g. lab)
+          
+        Returns: 
+            Config: A configuration object with the merged valued
+    """
 
     notebook_config = load_config(notebook_config_name, argv)
     server_config = load_config(server_config_name, argv)
@@ -29,6 +45,8 @@ def shim_configs(notebook_config_name: None, server_config_name: None, extension
     return merged_config
 
 def _print_warnings(notebook_config, server_config):
+    """Print warnings if the notebooik_config still contains traits.
+    """
     deprecated = list(notebook_config.NotebookApp.keys())
     if deprecated:
         print("==============================================================================================")

--- a/nbclassic/shimconfig.py
+++ b/nbclassic/shimconfig.py
@@ -18,7 +18,7 @@ def load_config(conf_name, argv):
     conf = ConfLoader(conf_name, argv)
     return conf.config
 
-def shim_configs(notebook_config_name: None, server_config_name: None, extension_config_name: None, argv=None):
+def merge_notebook_configs(notebook_config_name: None, server_config_name: None, other_config_name: None, argv=None):
     """Merge the notebook, server and your extension configurations and prints warnings in case
     the notebook configuration still contains NotebookApp traits.
   
@@ -33,18 +33,19 @@ def shim_configs(notebook_config_name: None, server_config_name: None, extension
 
     notebook_config = load_config(notebook_config_name, argv)
     server_config = load_config(server_config_name, argv)
-    extension_config = load_config(extension_config_name, argv)
+    other_config = load_config(other_config_name, argv)
 
-    _print_warnings(notebook_config, server_config)
+    _print_warnings(notebook_config)
 
     merged_config = Config()
     merged_config.ServerApp = notebook_config.NotebookApp
     merged_config.merge(notebook_config)
     merged_config.merge(server_config)
-    merged_config.merge(extension_config)
+    merged_config.merge(other_config)
+    
     return merged_config
 
-def _print_warnings(notebook_config, server_config):
+def _print_warnings(notebook_config):
     """Print warnings if the notebooik_config still contains traits.
     """
     deprecated = list(notebook_config.NotebookApp.keys())

--- a/nbclassic/shimconfig.py
+++ b/nbclassic/shimconfig.py
@@ -31,12 +31,12 @@ def shim_configs(notebook_config_name: None, server_config_name: None, extension
 def _print_warnings(notebook_config, server_config):
     deprecated = list(notebook_config.NotebookApp.keys())
     if deprecated:
-        print("=========================================================================================")
+        print("==============================================================================================")
         print("You are using NotebookApp settings that will be deprecated at the next major notebook release.")
         print("Please migrate following settings from NotebookApp to ServerApp:")
         print("  {}".format(deprecated))
-        print("Read more on https://...")
-        print("=========================================================================================")
+        print("Read more on https://jupyter-server.readthedocs.io/en/latest/migrate-from-notebook.html")
+        print("==============================================================================================")
         warnings.warn(
             "NotebookApp configuration is deprecated. Migrate them to ServerApp",
             DeprecationWarning, stacklevel=2,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[tool:pytest]
+addopts =
+	--color=yes
+    -s

--- a/setup.py
+++ b/setup.py
@@ -87,4 +87,9 @@ setup(
             'jupyter-nbclassic = nbclassic.notebookapp:main'
         ]
     },
+    extras_require = {
+        'test': [
+            'pytest'
+        ],
+    },
 )

--- a/tests/confs/jupyter_my_ext_config.py
+++ b/tests/confs/jupyter_my_ext_config.py
@@ -1,0 +1,1 @@
+c.MyExt.hello = 'My extension'

--- a/tests/confs/jupyter_notebook_config.py
+++ b/tests/confs/jupyter_notebook_config.py
@@ -1,0 +1,3 @@
+c.NotebookApp.allow_credentials = False
+c.NotebookApp.port = 8889
+c.NotebookApp.password_required = True

--- a/tests/confs/jupyter_server_config.py
+++ b/tests/confs/jupyter_server_config.py
@@ -1,0 +1,1 @@
+c.ServerApp.port = 7774

--- a/tests/shimconfig_test.py
+++ b/tests/shimconfig_test.py
@@ -1,0 +1,93 @@
+"""Test the shimming of the configs.
+"""
+
+import os.path
+from nbclassic.shimconfig import shim_configs
+
+test_conf_dir = os.path.join(os.getcwd(), 'tests', 'confs')
+os.chdir(test_conf_dir)
+
+def test_none():
+    """Test None parameters support.
+    """
+    merged = shim_configs(
+        notebook_config_name = None, 
+        server_config_name = None, 
+        extension_config_name = None, 
+        argv = []
+        )
+    assert merged.NotebookApp != None
+    assert merged.ServerApp != None
+    assert merged.MyExt != None
+
+def test_merge():
+    """Test NotebookApp are copied to ServerApp.
+    """
+
+    merged = shim_configs(
+        notebook_config_name = 'jupyter_notebook', 
+        server_config_name = 'jupyter_nbclassic', 
+        extension_config_name = 'jupyter_my_ext', 
+        argv = []
+        )
+
+    assert merged.NotebookApp.port == 8889
+    assert merged.NotebookApp.allow_credentials == False
+    assert merged.NotebookApp.password_required == True
+
+    assert merged.ServerApp.port == 8889
+    assert merged.ServerApp.allow_credentials == False
+    assert merged.ServerApp.password_required == True
+
+    assert merged.MyExt.hello == 'My extension'
+
+def test_merge_cli_order():
+    """Test NotebookApp are copied to ServerApp 
+    and CLI flags are processed.
+    """
+
+    merged = shim_configs(
+        notebook_config_name = 'jupyter_notebook', 
+        server_config_name = 'jupyter_nbclassic', 
+        extension_config_name = 'jupyter_my_ext', 
+        argv = [
+            '--NotebookApp.port=1111', 
+            ]
+        )
+
+    assert merged.NotebookApp.port == 1111
+    assert merged.NotebookApp.allow_credentials == True
+    assert merged.NotebookApp.password_required == True
+
+    assert merged.ServerApp.port == 1111
+    assert merged.ServerApp.allow_credentials == True
+    assert merged.ServerApp.password_required == True
+
+    assert merged.MyExt.hello == 'My extension'
+
+def test_merge_cli_order():
+    """Test NotebookApp are copied to ServerApp 
+    and CLI flags are processed in correct order.
+    """
+
+    merged = shim_configs(
+        notebook_config_name = 'jupyter_notebook', 
+        server_config_name = 'jupyter_nbclassic', 
+        extension_config_name = 'jupyter_my_ext', 
+        argv = [
+            '--NotebookApp.port=1111', 
+            '--ServerApp.port=2222', 
+            '--MyExt.more=True',
+            ]
+        )
+
+    assert merged.NotebookApp.port == 2222
+    assert merged.NotebookApp.allow_credentials == False
+    assert merged.NotebookApp.password_required == True
+
+    assert merged.ServerApp.port == 2222
+    assert merged.ServerApp.allow_credentials == False
+    assert merged.ServerApp.password_required == True
+
+    assert merged.MyExt.hello == 'My extension'
+    assert merged.MyExt.more == True


### PR DESCRIPTION
Initial config shim to support the migration of applications relying on notebook (e.g. jupyterlab) to migrate to jupyter server.

This PR is responsible to merge the NotebookApp to ServerApp without filtering.

A second PR would be responsible to bring more control on the merge rules.