### PR TITLE
update tests to handle changes in jupyter server extension manager

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 4
@@ -27,7 +26,7 @@ jobs:
         python -m pip install --upgrade pip
         git clone https://github.com/jupyter/jupyter_server.git
         cd jupyter_server
-        pip install -e .[test]
+        pip install -e .
         cd ..
         pip install -e .[test]
     - name: Test with pytest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -24,11 +24,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -v -e ".[test]"
-        cd ..
-        git clone https://github.com/jupyter/jupyter_server.git
-        cd jupyter_server
-        pip install -e .
-        cd ../nbclassic
+        pip install -U git+https://github.com/jupyter/jupyter_server.git
     - name: Test with pytest
       run: |
         pytest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -25,8 +25,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install git+https://github.com/jupyter/jupyter_server
         pip install -e .[test]
+        pip install -U git+https://github.com/jupyter/jupyter_server
     - name: Test with pytest
       run: |
         pytest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -26,7 +26,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[test]
-        pip install -U git+https://github.com/jupyter/jupyter_server
+        git clone https://github.com/jupyter/jupyter_server.git
+        cd jupyter_server
+        pip install -e .[test]
+        cd ..
     - name: Test with pytest
       run: |
         pytest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -24,11 +24,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install -v -e ".[test]"
         git clone https://github.com/jupyter/jupyter_server.git
         cd jupyter_server
         pip install -e .
         cd ..
-        pip install -e .[test]
     - name: Test with pytest
       run: |
         pytest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,10 +9,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [ '3.5', '3.6', '3.7', '3.8' ]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -26,6 +26,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -v -e ".[test]"
     - name: Install Jupyter Server from source
+      run: |
         cd ..
         git clone https://github.com/jupyter/jupyter_server.git
         cd jupyter_server

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -24,7 +24,12 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -v -e ".[test]"
-        pip install -U git+https://github.com/jupyter/jupyter_server.git
+    - name: Install Jupyter Server from source
+        cd ..
+        git clone https://github.com/jupyter/jupyter_server.git
+        cd jupyter_server
+        pip install -e .
+        cd ../nbclassic
     - name: Test with pytest
       run: |
         pytest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -11,7 +11,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 4
       matrix:
         python-version: [3.6, 3.7, 3.8]
 
@@ -25,10 +24,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -v -e ".[test]"
+        cd ..
         git clone https://github.com/jupyter/jupyter_server.git
         cd jupyter_server
         pip install -e .
-        cd ..
+        cd ../nbclassic
     - name: Test with pytest
       run: |
         pytest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -24,8 +24,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        pip install git+https://github.com/jupyter/jupyter_server
         python -m pip install --upgrade pip
+        pip install git+https://github.com/jupyter/jupyter_server
         pip install -e .[test]
     - name: Test with pytest
       run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -2,7 +2,7 @@ name: Testing nbclassic
 
 on:
   push:
-    branches: 
+    branches:
     - master
   pull_request:
     branches: '*'
@@ -24,6 +24,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        pip install git+https://github.com/jupyter/jupyter_server
         python -m pip install --upgrade pip
         pip install -e .[test]
     - name: Test with pytest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -25,11 +25,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[test]
         git clone https://github.com/jupyter/jupyter_server.git
         cd jupyter_server
         pip install -e .[test]
         cd ..
+        pip install -e .[test]
     - name: Test with pytest
       run: |
         pytest

--- a/nbclassic/nbserver.py
+++ b/nbclassic/nbserver.py
@@ -71,28 +71,28 @@ def _link_jupyter_server_extension(serverapp):
     # to incorporate a dependency injection system in the
     # Extension manager that allows extensions to list
     # their dependency tree and sort that way.
-    def enabled_extensions(self):
+    def extensions(self):
         """Dictionary with extension package names as keys
         and an ExtensionPackage objects as values.
         """
         # Pop out the nbclassic extension to prepend
         # this extension at the front of the sorted server extensions.
-        nb = self._enabled_extensions.get("nbclassic")
+        nb = self._extensions.get("nbclassic")
         # Sort all other extensions alphabetically.
-        other_extensions = dict(sorted(self._enabled_extensions.items()))
+        other_extensions = dict(sorted(self._extensions.items()))
         # Build a new extensions dictionary, sorted with nbclassic first.
         sorted_extensions = {"nbclassic": nb}
         sorted_extensions.update(**other_extensions)
         return sorted_extensions
 
-    manager.__class__.enabled_extensions = property(enabled_extensions)
+    manager.__class__.extensions = property(extensions)
 
     # Look to see if nbclassic is enabled. if so,
     # link the nbclassic extension here to load
     # its config. Then, port its config to the serverapp
     # for backwards compatibility.
     try:
-        pkg = manager.enabled_extensions["nbclassic"]
+        pkg = manager.extensions["nbclassic"]
         pkg.link_point("jupyter-nbclassic", serverapp)
         point = pkg.extension_points["jupyter-nbclassic"]
         nbapp = point.app

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup_args = dict(
     ],
     cmdclass         = cmdclass,
     zip_safe=False,
-    python_requires='>=3.6',
+    python_requires='>=3.5',
     include_package_data=True,
     install_requires = [
         'jupyter_server>=0.3',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import pytest
 from traitlets import default
 from nbclassic.notebookapp import NotebookApp
 
-pytest_plugins = "pytest_jupyter_server"
+pytest_plugins = ["pytest_jupyter_server"]
 
 
 @pytest.fixture

--- a/tests/shim/mockextension.py
+++ b/tests/shim/mockextension.py
@@ -8,7 +8,7 @@ from jupyter_server.extension.application import ExtensionApp
 from nbclassic import shim
 
 
-def _jupyter_server_extension_paths():
+def _jupyter_server_extension_points():
     return [
         {
             "module": "tests.shim.mockextension",
@@ -22,7 +22,7 @@ class MockExtensionApp(
     ExtensionApp
 ):
     """Mock an extension app that previously inherited NotebookApp."""
-    extension_name = 'mockextension'
+    name = 'mockextension'
 
     # ------ Traits found ServerApp, NotebookApp, and MockExtensionApp
 

--- a/tests/shim/test_extension.py
+++ b/tests/shim/test_extension.py
@@ -53,7 +53,7 @@ def server_config():
 
 @pytest.fixture
 def extensionapp(serverapp):
-    return serverapp._enabled_extensions["mockextension"]
+    return serverapp.extension_manager.extension_points["mockextension"].app
 
 
 def list_test_params(param_input):

--- a/tests/shim/test_nbclassic.py
+++ b/tests/shim/test_nbclassic.py
@@ -16,7 +16,7 @@ def server_config():
 
 @pytest.fixture
 def nbclassic(serverapp):
-    return serverapp._enabled_extensions["nbclassic"]
+    return serverapp.extension_manager.extension_points["nbclassic"].app
 
 
 def list_test_params(param_input):


### PR DESCRIPTION
Minor updates after jupyter/jupyter_server#248 was merged.

Adds Python 3.5 to nbclassic's supported Python versions.