### PR TITLE
Fix import of helper function

### DIFF
--- a/nbclassic/nbserver.py
+++ b/nbclassic/nbserver.py
@@ -4,7 +4,7 @@ import inspect
 from functools import wraps
 from jupyter_core.paths import jupyter_config_path
 from jupyter_server.services.config.manager import ConfigManager
-from traitlets import is_trait
+from traitlets.traitlets import is_trait
 from .traits import NotebookAppTraits
 
 


### PR DESCRIPTION
In `traitlets 5+` this function is no longer exported at the top level.